### PR TITLE
Cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .POSIX:
 
-CC?=cc
-CPPFLAGS=-lX11 -Wall -Wextra -fPIE -O2 -D_FORTIFY_SOURCE=2
-SOURCE=swallow.c
+CC=cc
+CPPFLAGS=-Wall -Wextra -fPIE -O2 -D_FORTIFY_SOURCE=2
+LDLIBS=-lX11
+
 TARGET=swallow
 
 PREFIX=/usr/local
 
 build: $(TARGET)
-	$(CC) $(CPPFLAGS) $(SOURCE) -o $(TARGET)
 
 install: build
 	cp $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ build: $(TARGET)
 	$(CC) $(CPPFLAGS) $(SOURCE) -o $(TARGET)
 
 install: build
-	cp $(TARGET) $(PREFIX)$(TARGET)
+	cp $(TARGET) $(DESTDIR)$(PREFIX)$(TARGET)
 
 uninstall:
-	rm -f $(PREFIX)$(TARGET)
+	rm -f $(DESTDIR)$(PREFIX)$(TARGET)
 
 clean:
 	rm -f $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ CC?=cc
 CPPFLAGS=-lX11 -Wall -Wextra -fPIE -O2 -D_FORTIFY_SOURCE=2
 SOURCE=swallow.c
 TARGET=swallow
-PREFIX=/usr/local/bin/
+
+PREFIX=/usr/local
 
 build: $(TARGET)
 	$(CC) $(CPPFLAGS) $(SOURCE) -o $(TARGET)
 
 install: build
-	cp $(TARGET) $(DESTDIR)$(PREFIX)$(TARGET)
+	cp $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)$(TARGET)
+	rm -f $(DESTDIR)$(PREFIX)/bin/$(TARGET)
 
 clean:
 	rm -f $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PREFIX=/usr/local
 build: $(TARGET)
 
 install: build
-	cp $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	install -D $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/$(TARGET)


### PR DESCRIPTION
- DESTDIR support
- PREFIX should not include type-folder
- rely on correct implicit build rule

see individual commit messages for explanations.